### PR TITLE
Bug #69252: Tại phần checkout, fill sẵn thông tin địa chỉ của user

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -256,7 +256,7 @@ class CheckoutView(LoginRequiredMixin, View):
             )
             if shipping_address_qs.exists():
                 context.update(
-                    {'default_shipping_address': shipping_address_qs[0]})
+                    {'default_shipping_address': shipping_address_qs.last()})
 
             billing_address_qs = Address.objects.filter(
                 user=self.request.user,
@@ -265,7 +265,7 @@ class CheckoutView(LoginRequiredMixin, View):
             )
             if billing_address_qs.exists():
                 context.update(
-                    {'default_billing_address': billing_address_qs[0]})
+                    {'default_billing_address': billing_address_qs.last()})
             return render(self.request, "checkout.html", context)
         except ObjectDoesNotExist:
             messages.info(self.request, _("You do not have an active order"))

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -20,12 +20,12 @@
               <div class='hideable_shipping_form'>
 
                 <div class="md-form mb-5">
-                  <input type='text' placeholder="{% trans 'Street' %}" id='shipping_address' name='shipping_address' class='form-control' required />
+                  <input type='text' placeholder="{% trans 'Street' %}" id='shipping_address' name='shipping_address' class='form-control' value="{{ default_shipping_address.street_address }}" required />
                   <label for="shipping_address" class="">{% trans "Address" %}</label>
                 </div>
 
                 <div class="md-form mb-5">
-                  <input type='text' placeholder="{% trans 'Apartment or suite' %}" id='shipping_address2' name='shipping_address2' class='form-control' />
+                  <input type='text' placeholder="{% trans 'Apartment or suite' %}" id='shipping_address2' name='shipping_address2' class='form-control' value="{{ default_shipping_address.apartment_address }}"/>
                   <label for="shipping_address2" class="">{% trans "Address 2 (optional)" %}</label>
                 </div>
 
@@ -39,7 +39,7 @@
                   </div>
                   <div class="col-lg-4 col-md-6 mb-4">
                     <label for="shipping_zip">Zip</label>
-                    <input type='text' placeholder="{% trans 'Zip code' %}" id='shipping_zip' name='shipping_zip' class='form-control' required/>
+                    <input type='text' placeholder="{% trans 'Zip code' %}" id='shipping_zip' name='shipping_zip' class='form-control' value="{{ default_shipping_address.zip }}" required/>
                     <div class="invalid-feedback">
                       {% trans "Zip code required." %}
                     </div>
@@ -53,25 +53,18 @@
 
               </div>
 
-              {% if default_shipping_address %}
-              <div class="custom-control custom-checkbox">
-                <input type="checkbox" class="custom-control-input" name="use_default_shipping" id="use_default_shipping">
-                <label class="custom-control-label" for="use_default_shipping">{% trans "Use default shipping address" %}: {{ default_shipping_address.street_address|truncatechars:10 }}</label>
-              </div>
-              {% endif %}
-
               <hr>
 
               <h3>{% trans "Billing address" %}</h3>
 
               <div class='hideable_billing_form'>
                 <div class="md-form mb-5">
-                  <input type='text' placeholder="{% trans 'Street' %}" id='billing_address' name='billing_address' class='form-control' required/>
+                  <input type='text' placeholder="{% trans 'Street' %}" id='billing_address' name='billing_address' class='form-control' value="{{ default_billing_address.street_address }}" required/>
                   <label for="billing_address" class="">{% trans "Address" %}</label>
                 </div>
 
                 <div class="md-form mb-5">
-                  <input type='text' placeholder="{% trans 'Apartment or suite' %}" id='billing_address2' name='billing_address2' class='form-control' />
+                  <input type='text' placeholder="{% trans 'Apartment or suite' %}" id='billing_address2' name='billing_address2' class='form-control' value="{{ default_billing_address.apartment_address }}" />
                   <label for="billing_address2" class="">{% trans "Address 2 (optional)" %}</label>
                 </div>
 
@@ -86,27 +79,20 @@
 
                   <div class="col-lg-4 col-md-6 mb-4">
                     <label for="billing_zip">Zip</label>
-                    <input type='text' placeholder="{% trans 'Zip code' %}" id='billing_zip' name='billing_zip' class='form-control' required/>
+                    <input type='text' placeholder="{% trans 'Zip code' %}" id='billing_zip' name='billing_zip' class='form-control' value="{{ default_billing_address.zip }}" required/>
                     <div class="invalid-feedback">
                       {% trans "Zip code required." %}
                     </div>
                   </div>
 
                 </div>
-
+      
                 <div class="custom-control custom-checkbox">
                   <input type="checkbox" class="custom-control-input" name="set_default_billing" id="set_default_billing">
                   <label class="custom-control-label" for="set_default_billing">{% trans "Save as default billing address" %}</label>
                 </div>
 
               </div>
-
-              {% if default_billing_address %}
-              <div class="custom-control custom-checkbox">
-                <input type="checkbox" class="custom-control-input" name="use_default_billing" id="use_default_billing">
-                <label class="custom-control-label" for="use_default_billing">{% trans "Use default billing address" %}: {{ default_billing_address.street_address|truncatechars:10 }}</label>
-              </div>
-              {% endif %}
               <hr>
 
               <h3>{% trans "Payment option" %}</h3>


### PR DESCRIPTION
## Related Tickets
- ticket redmine [69252](https://edu-redmine.sun-asterisk.vn/issues/69252)

## WHAT (optional)
- Nếu user có địa chỉ default thì điền luôn vào ô input

## HOW
- Trong template chức năng thanh toán, thay đổi value ở ô input để địa chỉ đó được điền sẵn trong ô input

## WHY (optional)
- Do trước đó đã làm tính năng lưu địa chỉ mặc định của người dùng vào database

## Evidence (Screenshot or Video)
![image](https://github.com/awesome-academy/hn_python_naitei19-ecommerce/assets/86515768/89c98f77-5a65-4bd0-8f53-75c0bb67a6c9)


## Notes (Kiến thức tìm hiểu thêm)
